### PR TITLE
fix/multiple markdownlint parameters

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -5,7 +5,7 @@ cd "${GITHUB_WORKSPACE}" || exit
 export REVIEWDOG_GITHUB_API_TOKEN="${INPUT_GITHUB_TOKEN}"
 
 # shellcheck disable=SC2086
-markdownlint "${INPUT_MARKDOWNLINT_FLAGS:-.}" 2>&1 \
+markdownlint ${INPUT_MARKDOWNLINT_FLAGS:-.} 2>&1 \
   | reviewdog \
       -efm="%f:%l:%c %m" \
       -efm="%f:%l %m" \
@@ -19,7 +19,7 @@ markdownlint "${INPUT_MARKDOWNLINT_FLAGS:-.}" 2>&1 \
  # github-pr-review only diff adding
 if [ "${INPUT_REPORTER}" = "github-pr-review" ]; then
   # fix
-  markdownlint --fix "${INPUT_MARKDOWNLINT_FLAGS:-.}" 2>&1 || true
+  markdownlint --fix ${INPUT_MARKDOWNLINT_FLAGS:-.} 2>&1 || true
 
   TMPFILE=$(mktemp)
   git diff > "${TMPFILE}"


### PR DESCRIPTION
If you try to add multiple flags in the _markdownlint_flags_ the actions fails because it only supports one parameter.

i.e.
```yml
      - run: markdownlint '**/*.md' -c .github/config/lint-config.yml
          github_token: ${{ secrets.GITHUB_TOKEN }}
          reporter: github-pr-review
          markdownlint_flags: --config .github/config/lint-config.yml .
```
fails with following error:

```bash
  error: unknown option `--config .github/config/lint-config.yml .'
```
