### PR TITLE
Use github.token by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ code review experience.
 inputs:
   github_token:
     description: 'GITHUB_TOKEN.'
-    required: true
+    default: '${{ github.token }}'
   ### Flags for reviewdog ###
   level:
     description: 'Report level for reviewdog [info,warning,error]'

--- a/action.yml
+++ b/action.yml
@@ -4,7 +4,7 @@ author: 'prologic'
 inputs:
   github_token:
     description: 'GITHUB_TOKEN.'
-    required: true
+    default: '${{ github.token }}'
   ### Flags for reviewdog ###
   level:
     description: 'Report level for reviewdog [info,warning,error]'


### PR DESCRIPTION
Hi! Thank you for a pretty GitHub Action 🐶

I would suggest to use `github.token` by default for `GITHUB_TOKEN` as well as the following actions and templates.

- <https://github.com/reviewdog/action-remark-lint/blob/v5.6.0/action.yml#L20-L23>
- <https://github.com/reviewdog/action-template/blob/v1.10.1/action.yml#L5-L7>
- <https://github.com/reviewdog/action-shellcheck/pull/7>

Please check my changes and merge them if you like it. Thanks!
