### PR TITLE
ci: replace create-release deprecated action

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,14 +38,11 @@ jobs:
           if_false: ${{ steps.bumpr.outputs.next_version }}
 
       # Create release.
-      - uses: actions/create-release@v1
+      - uses: softprops/action-gh-release@v1
         if: "steps.tag.outputs.value != ''"
-        env:
-          # This token is provided by Actions, you do not need to create your own token
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           tag_name: ${{ steps.tag.outputs.value }}
-          release_name: Release ${{ steps.tag.outputs.value }}
+          name: Release ${{ steps.tag.outputs.value }}
           body: ${{ steps.bumpr.outputs.message }}
           draft: false
           prerelease: false


### PR DESCRIPTION
The current action is deprecated and will stop working eventually when due to Node.js 12 actions being deprecated.

Switching to a new action to fix the warnings and keep working