### PR TITLE
base image change

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,8 @@ RUN apt-get update \
         wget \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
-RUN wget -O - -q https://raw.githubusercontent.com/reviewdog/reviewdog/master/install.sh \
+RUN set -eux \
+    && wget -O - -q https://raw.githubusercontent.com/reviewdog/reviewdog/master/install.sh \
     | sh -s -- -b /usr/local/bin/ ${REVIEWDOG_VERSION}
 
 COPY entrypoint.sh /entrypoint.sh

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:18-alpine3.14
+FROM node:20-alpine3.19
 
 ENV MARKDOWNLINT_CLI_VERSION=v0.37.0
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,9 +6,14 @@ RUN npm install -g "markdownlint-cli@$MARKDOWNLINT_CLI_VERSION"
 
 ENV REVIEWDOG_VERSION=v0.15.0
 
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+        git \
+        wget \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/*
 RUN wget -O - -q https://raw.githubusercontent.com/reviewdog/reviewdog/master/install.sh \
     | sh -s -- -b /usr/local/bin/ ${REVIEWDOG_VERSION}
-RUN apk --no-cache -U add git
 
 COPY entrypoint.sh /entrypoint.sh
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:20-alpine3.19
+FROM node:16-alpine3.12
 
 ENV MARKDOWNLINT_CLI_VERSION=v0.37.0
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:16-alpine3.12
+FROM node:18-bullseye-slim
 
 ENV MARKDOWNLINT_CLI_VERSION=v0.37.0
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,12 +8,12 @@ ENV REVIEWDOG_VERSION=v0.15.0
 
 RUN apt-get update \
     && apt-get install -y --no-install-recommends \
+        ca-certificates \
         git \
         wget \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
-RUN set -eux \
-    && wget -O - -q https://raw.githubusercontent.com/reviewdog/reviewdog/master/install.sh \
+RUN wget -O - -q https://raw.githubusercontent.com/reviewdog/reviewdog/master/install.sh \
     | sh -s -- -b /usr/local/bin/ ${REVIEWDOG_VERSION}
 
 COPY entrypoint.sh /entrypoint.sh


### PR DESCRIPTION
When building on a rootless docker self-hosted runner, reviewdog installation fails with `wget: bad address 'github.com'`.
This seems to be an issue with alpine image and appears after 3.13.
I think the minimum fix is to downgrade to alpine 3.12 or use a different OS image.

https://github.com/alpinelinux/docker-alpine/issues/155

| image | result |
|:--|:--|
|node:16-alpine3.12|OK|
|node:18-alpine3.14|NG|
|node:20-alpine3.19|NG|
|node:18-bullseye-slim|OK|