### PR TITLE
Add fail_level and deduplicate fail_on_error

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,8 @@ inputs:
     default: 'added'
   fail_level:
     description: |
-      If set to `none`, always use exit code 0 for reviewdog. Otherwise, exit code 1 for reviewdog if it finds at least 1 issue with severity greater than or equal to the given level.
+      If set to `none`, always use exit code 0 for reviewdog.
+      Otherwise, exit code 1 for reviewdog if it finds at least 1 issue with severity greater than or equal to the given level.
       Possible values: [none,any,info,warning,error]
       Default is `none`.
     default: 'none'

--- a/README.md
+++ b/README.md
@@ -28,10 +28,18 @@ inputs:
       Filtering mode for the reviewdog command [added,diff_context,file,nofilter].
       Default is added.
     default: 'added'
+  fail_level:
+    description: |
+      If set to `none`, always use exit code 0 for reviewdog. Otherwise, exit code 1 for reviewdog if it finds at least 1 issue with severity greater than or equal to the given level.
+      Possible values: [none,any,info,warning,error]
+      Default is `none`.
+    default: 'none'
   fail_on_error:
     description: |
+      Deprecated, use `fail_level` instead.
       Exit code for reviewdog when errors are found [true,false]
       Default is `false`.
+    deprecationMessage: Deprecated, use `fail_level` instead.
     default: 'false'
   reviewdog_flags:
     description: 'Additional reviewdog flags'

--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ code review experience.
 
 ## Inputs
 
+<!-- markdownlint-disable MD013 -->
 ```yml
 inputs:
   github_token:
@@ -50,6 +51,7 @@ inputs:
     description: "Options of markdownlint-cli command. Default: '.'"
     default: '.'
 ```
+<!-- markdownlint-enable MD013 -->
 
 ## Example usage
 

--- a/action.yml
+++ b/action.yml
@@ -17,10 +17,18 @@ inputs:
       Filtering mode for the reviewdog command [added,diff_context,file,nofilter].
       Default is added.
     default: 'added'
+  fail_level:
+    description: |
+      If set to `none`, always use exit code 0 for reviewdog. Otherwise, exit code 1 for reviewdog if it finds at least 1 issue with severity greater than or equal to the given level.
+      Possible values: [none,any,info,warning,error]
+      Default is `none`.
+    default: 'none'
   fail_on_error:
     description: |
+      Deprecated, use `fail_level` instead.
       Exit code for reviewdog when errors are found [true,false]
       Default is `false`.
+    deprecationMessage: Deprecated, use `fail_level` instead.
     default: 'false'
   reviewdog_flags:
     description: 'Additional reviewdog flags'

--- a/action.yml
+++ b/action.yml
@@ -19,7 +19,8 @@ inputs:
     default: 'added'
   fail_level:
     description: |
-      If set to `none`, always use exit code 0 for reviewdog. Otherwise, exit code 1 for reviewdog if it finds at least 1 issue with severity greater than or equal to the given level.
+      If set to `none`, always use exit code 0 for reviewdog.
+      Otherwise, exit code 1 for reviewdog if it finds at least 1 issue with severity greater than or equal to the given level.
       Possible values: [none,any,info,warning,error]
       Default is `none`.
     default: 'none'

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -13,6 +13,7 @@ markdownlint ${INPUT_MARKDOWNLINT_FLAGS:-.} 2>&1 \
       -name="markdownlint" \
       -reporter="${INPUT_REPORTER:-github-pr-check}" \
       -filter-mode="${INPUT_FILTER_MODE}" \
+      -fail-level="${INPUT_FAIL_LEVEL}" \
       -fail-on-error="${INPUT_FAIL_ON_ERROR}" \
       -level="${INPUT_LEVEL}" \
       ${INPUT_REVIEWDOG_FLAGS} || EXIT_CODE=$?


### PR DESCRIPTION
In https://github.com/reviewdog/reviewdog/pull/1854, we add `-fail-level` to reviewdog and deduplicate `-fail-on-error`.
I apply it to this actions.