### PR TITLE
fix: move base image to bookworm

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:24-bullseye-slim
+FROM node:24-bookworm-slim
 
 ENV MARKDOWNLINT_CLI_VERSION=v0.49.1
 


### PR DESCRIPTION
## Summary

Change the action base image from `node:24-bullseye-slim` to `node:24-bookworm-slim`.

The immediate failure motivating this change was inconsistent Debian repository state: a fresh Bullseye APT index advertised `libperl5.32_5.32.1-4+deb11u5`, while the referenced package file returned HTTP 404. Bullseye end-of-life did not directly cause that individual 404. However, Debian ended Bullseye LTS support on August 31, 2026, so it no longer receives normal Debian security maintenance and its repositories are transitioning. Building the action from that base on every invocation therefore creates ongoing reliability and security-maintenance risk.

Bookworm is still supported by Debian and retains the same Node.js major version, markdownlint version, reviewdog version, entrypoint, and action interface.

## Verification

- `docker build -t action-markdownlint:bookworm .`
- Verified the built image reports:
  - Node.js `v24.20.0`
  - markdownlint-cli `0.49.1`
  - reviewdog `0.21.0`

## References

- [Debian 11 Long Term Support reaches end-of-life](https://www.debian.org/News/2026/20260831)
- [Debian Bullseye release lifecycle](https://www.debian.org/releases/bullseye/)
- [Report showing the Bullseye index/package 404 mismatch](https://github.com/DIG-Network/dig-node/issues/565)
- [Request to publish prebuilt action images](https://github.com/reviewdog/action-markdownlint/issues/81)
